### PR TITLE
Adding hdpi manifest into runtime.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ tkdnd is from https://github.com/petasis/tkdnd/releases
 
 
 Manually added our ico to runtime.exe as sdx seems unable to otherwise replace them all
+
+We also unwrap and rewrapped runtime.exe to mt.exe add the app.manifest for high DPI settings

--- a/app.manifest
+++ b/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+</application>
+</assembly>


### PR DESCRIPTION
```
.\tclkit\tclkit.exe .\sdx\sdx.kit unwrap runtime.exe  
& 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\mt.exe' -manifest ..\app.manifest -outputresource:runtime.exe;#1
.\tclkit\tclkit.exe .\sdx\sdx.kit wrap runtime -runtime runtime.exe
```
then move runtime to runtime.exe


ps there is also https://github.com/avih/perc instead of mt.exe